### PR TITLE
Bug fix sending messages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
       "version": "0.1.0",
       "dependencies": {
         "@material-ui/core": "^4.11.0",

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -13,9 +13,14 @@ export const addMessageToStore = (state, payload) => {
 
   return state.map((convo) => {
     if (convo.id === message.conversationId) {
-      convo.messages.push(message);
-      convo.latestMessageText = message.text;
-      return convo;
+      return {
+        ...convo,
+        latestMessageText: message.text,
+        messages: [
+          ...convo.messages,
+          message
+        ]
+      }
     } else {
       return convo;
     }
@@ -69,10 +74,15 @@ export const addSearchedUsersToStore = (state, users) => {
 export const addNewConvoToStore = (state, recipientId, message) => {
   return state.map((convo) => {
     if (convo.otherUser.id === recipientId) {
-      convo.id = message.conversationId;
-      convo.messages.push(message);
-      convo.latestMessageText = message.text;
-      return convo;
+      return {
+        ...convo,
+        id: message.conversationId,
+        latestMessageText: message.text,
+        messages: [
+          ...convo.messages,
+          message
+        ]
+      }
     } else {
       return convo;
     }

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -11,20 +11,23 @@ export const addMessageToStore = (state, payload) => {
     return [newConvo, ...state];
   }
 
-  return state.map((convo) => {
-    if (convo.id === message.conversationId) {
-      return {
-        ...convo,
-        latestMessageText: message.text,
-        messages: [
-          ...convo.messages,
-          message
-        ]
-      }
-    } else {
-      return convo;
-    }
-  });
+  // the conversation with the latest message should go to the top of the conversations
+  // sorting (the simpler solution) is O(n log(n)) but this solution is O(n)
+  const convoToUpdate = state.find(convo => convo.id === message.conversationId);
+  const updatedConvo = {
+    ...convoToUpdate,
+    latestMessageText: message.text,
+    messages: [
+      ...convoToUpdate.messages,
+      message
+    ]
+  }
+  const otherConvos = state.filter(convo => convo.id !== message.conversationId);
+
+  return [
+    updatedConvo,
+    ...otherConvos
+  ];
 };
 
 export const addOnlineUserToStore = (state, id) => {

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -72,21 +72,7 @@ export const logout = (id) => async (dispatch) => {
 export const fetchConversations = () => async (dispatch) => {
   try {
     const { data } = await axios.get("/api/conversations");
-    
-    // Messages are sorted here rather than in the component because
-    // the messages only come in the incorrect order when they're retrieved
-    // This way the sorting function which requires O(n log(n)) only runs once per conversation
-    // Otherwise the messages would be sorted every time the component renders a different conversation
-    const sortedData = [...data];
-    for (let i = 0; i < sortedData.length; i++) {
-      sortedData[i].messages = sortedData[i].messages.sort((firstMessage, secondMessage) => {
-        const firstMessageSentAt = new Date(firstMessage.createdAt);
-        const secondMessageSentAt = new Date(secondMessage.createdAt);
-        return firstMessageSentAt - secondMessageSentAt;
-      })
-    }
-
-    dispatch(gotConversations(sortedData));
+    dispatch(gotConversations(data));
   } catch (error) {
     console.error(error);
   }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "server",
       "version": "0.0.0",
       "dependencies": {
         "connect-session-sequelize": "^7.0.4",

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -19,9 +19,9 @@ router.get("/", async (req, res, next) => {
         },
       },
       attributes: ["id"],
-      order: [[Message, "createdAt", "DESC"]],
+      order: [[Message, "createdAt", "ASC"]],
       include: [
-        { model: Message, order: ["createdAt", "DESC"] },
+        { model: Message, order: ["createdAt", "ASC"] },
         {
           model: User,
           as: "user1",

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -19,9 +19,9 @@ router.get("/", async (req, res, next) => {
         },
       },
       attributes: ["id"],
-      order: [[Message, "createdAt", "ASC"]],
+      order: [[Message, "createdAt", "DESC"]],
       include: [
-        { model: Message, order: ["createdAt", "ASC"] },
+        { model: Message },
         {
           model: User,
           as: "user1",
@@ -69,6 +69,9 @@ router.get("/", async (req, res, next) => {
 
       // set properties for notification count and latest message preview
       convoJSON.latestMessageText = convoJSON.messages[0].text;
+
+      // We need the messages in ASC order but need to return them in DESC order
+      convoJSON.messages.reverse();
       conversations[i] = convoJSON;
     }
 

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -70,7 +70,7 @@ router.get("/", async (req, res, next) => {
       // set properties for notification count and latest message preview
       convoJSON.latestMessageText = convoJSON.messages[0].text;
 
-      // We need the messages in ASC order but need to return them in DESC order
+      // we need the conversations in DESC order but need the messages in ASC order
       convoJSON.messages.reverse();
       conversations[i] = convoJSON;
     }


### PR DESCRIPTION
New messages weren't correctly updating in the client for two reasons.
1. postMessage in thunkCreators contacted the backend to create a new message. However, it did not let the promise resolve and still used the data.
2. addMessageToStore and addNewConvoToStore mutated the redux state, preventing the components from updating.

Messages weren't sorted correctly because when a conversation loaded, they were retrieved from the database in descending order. However, the client side should display the messages in ascending order.