### PR TITLE
Ticket #2: Add read status for messages

### DIFF
--- a/client/src/Login.js
+++ b/client/src/Login.js
@@ -28,7 +28,7 @@ const Login = (props) => {
   }
 
   return (
-    <Grid container justify="center">
+    <Grid container justifyContent="center">
       <Box>
         <Grid container item>
           <Typography>Need to register?</Typography>

--- a/client/src/Signup.js
+++ b/client/src/Signup.js
@@ -37,7 +37,7 @@ const Login = (props) => {
   }
 
   return (
-    <Grid container justify="center">
+    <Grid container justifyContent="center">
       <Box>
         <Grid container item>
           <Typography>Need to log in?</Typography>

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -35,6 +35,7 @@ const ActiveChat = (props) => {
           />
           <Box className={classes.chatContainer}>
             <Messages
+              lastReadMessageIndex={conversation.lastReadMessageIndex}
               messages={conversation.messages}
               otherUser={conversation.otherUser}
               userId={user.id}

--- a/client/src/components/ActiveChat/LastReadAvatar.js
+++ b/client/src/components/ActiveChat/LastReadAvatar.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { Box, Avatar } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end"
+  },
+  otherUserAvatar: {
+    height: 22,
+    width: 22
+  },
+}));
+
+const LastReadAvatar = (props) => {
+    const classes = useStyles();
+    const { alt, photoUrl } = props;
+    return (
+      <Box className={classes.root}>
+          <Avatar alt={alt} src={photoUrl} className={classes.otherUserAvatar} />
+      </Box>
+    );
+}
+
+export default LastReadAvatar;

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -1,20 +1,34 @@
 import React from "react";
-import { Box } from "@material-ui/core";
+import { Box, Collapse } from "@material-ui/core";
 import { SenderBubble, OtherUserBubble } from "../ActiveChat";
 import moment from "moment";
+import LastReadAvatar from "./LastReadAvatar";
 
 const Messages = (props) => {
-  const { messages, otherUser, userId } = props;
+  const { messages, otherUser, userId, lastReadMessageIndex } = props;
 
   return (
     <Box>
-      {messages.map((message) => {
+      {messages.map((message, idx) => {
         const time = moment(message.createdAt).format("h:mm");
 
         return message.senderId === userId ? (
-          <SenderBubble key={message.id} text={message.text} time={time} />
+          <React.Fragment key={message.id}>
+            <SenderBubble text={message.text} time={time} />
+            <Collapse in={lastReadMessageIndex === idx}>
+              <LastReadAvatar
+                alt={otherUser.username}
+                photoUrl={otherUser.photoUrl}
+              />
+            </Collapse>
+          </React.Fragment>
         ) : (
-          <OtherUserBubble key={message.id} text={message.text} time={time} otherUser={otherUser} />
+          <OtherUserBubble
+            key={message.id}
+            text={message.text}
+            time={time}
+            otherUser={otherUser}
+          />
         );
       })}
     </Box>

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -14,13 +14,13 @@ const Messages = (props) => {
 
         return message.senderId === userId ? (
           lastReadMessageIndex === idx ? (
-            <>
-              <SenderBubble key={message.id} text={message.text} time={time} />
+            <React.Fragment key={message.id}>
+              <SenderBubble text={message.text} time={time} />
                 <LastReadAvatar
                   alt={otherUser.username}
                   photoUrl={otherUser.photoUrl}
                 />
-            </>
+            </React.Fragment>
           ) : (
             <SenderBubble key={message.id} text={message.text} time={time} />
           )

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Collapse } from "@material-ui/core";
+import { Box } from "@material-ui/core";
 import { SenderBubble, OtherUserBubble } from "../ActiveChat";
 import moment from "moment";
 import LastReadAvatar from "./LastReadAvatar";
@@ -13,15 +13,17 @@ const Messages = (props) => {
         const time = moment(message.createdAt).format("h:mm");
 
         return message.senderId === userId ? (
-          <React.Fragment key={message.id}>
-            <SenderBubble text={message.text} time={time} />
-            <Collapse in={lastReadMessageIndex === idx}>
-              <LastReadAvatar
-                alt={otherUser.username}
-                photoUrl={otherUser.photoUrl}
-              />
-            </Collapse>
-          </React.Fragment>
+          lastReadMessageIndex === idx ? (
+            <>
+              <SenderBubble key={message.id} text={message.text} time={time} />
+                <LastReadAvatar
+                  alt={otherUser.username}
+                  photoUrl={otherUser.photoUrl}
+                />
+            </>
+          ) : (
+            <SenderBubble key={message.id} text={message.text} time={time} />
+          )
         ) : (
           <OtherUserBubble
             key={message.id}

--- a/client/src/components/Sidebar/BadgeAvatar.js
+++ b/client/src/components/Sidebar/BadgeAvatar.js
@@ -33,7 +33,7 @@ const UserAvatar = (props) => {
         classes={{ badge: `${classes.badge} ${online && classes.online}` }}
         variant="dot"
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-        overlap="circle">
+        overlap="circular">
         <Avatar alt={username} src={photoUrl} className={classes.profilePic}></Avatar>
       </Badge>
     </Box>

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -3,7 +3,7 @@ import { Box } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
 import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
-import { readConversation } from "../../store/utils/thunkCreators";
+import { readMessagesFromConversation } from "../../store/utils/thunkCreators";
 import { connect } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
@@ -27,7 +27,7 @@ const Chat = (props) => {
 
   const handleClick = async (conversation) => {
     if (conversation.unreadMessages) {
-      props.readConversation(conversation.id);
+      props.readMessagesFromConversation(conversation.id);
     }
     await props.setActiveChat(conversation.otherUser.username);
   };
@@ -47,8 +47,8 @@ const Chat = (props) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    readConversation: (id) => {
-      dispatch(readConversation(id));
+    readMessagesFromConversation: (id) => {
+      dispatch(readMessagesFromConversation(id));
     },
     setActiveChat: (id) => {
       dispatch(setActiveChat(id));

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -3,6 +3,7 @@ import { Box } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
 import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
+import { readConversation } from "../../store/utils/thunkCreators";
 import { connect } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
@@ -25,6 +26,9 @@ const Chat = (props) => {
   const { otherUser } = conversation;
 
   const handleClick = async (conversation) => {
+    if (conversation.unreadMessages) {
+      props.readConversation(conversation.id);
+    }
     await props.setActiveChat(conversation.otherUser.username);
   };
 
@@ -43,9 +47,12 @@ const Chat = (props) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
+    readConversation: (id) => {
+      dispatch(readConversation(id));
+    },
     setActiveChat: (id) => {
       dispatch(setActiveChat(id));
-    }
+    },
   };
 };
 

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -52,7 +52,7 @@ const ChatContent = (props) => {
           <Badge
             badgeContent={conversation.unreadMessages}
             color="primary"
-          />
+          ></Badge>
         </Box>
       </Zoom>
     </Box>

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@material-ui/core";
+import { Box, Typography, Chip, Zoom } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
@@ -15,16 +15,20 @@ const useStyles = makeStyles((theme) => ({
   },
   previewText: {
     fontSize: 12,
-    color: "#9CADC8",
-    letterSpacing: -0.17,
+    fontWeight: ({ hasUnreadMessages }) => (hasUnreadMessages ? "600" : "400"),
+    color: ({ hasUnreadMessages }) =>
+      hasUnreadMessages ? "rgba(0, 0, 0, 0.87)" : "#9CADC8",
+    transition: 'all 0.4s ease',
   },
 }));
 
 const ChatContent = (props) => {
-  const classes = useStyles();
-
   const { conversation } = props;
   const { latestMessageText, otherUser } = conversation;
+
+  const hasUnreadMessages = conversation.unreadMessages > 0;
+
+  const classes = useStyles({ hasUnreadMessages });
 
   return (
     <Box className={classes.root}>
@@ -36,6 +40,9 @@ const ChatContent = (props) => {
           {latestMessageText}
         </Typography>
       </Box>
+      <Zoom in={hasUnreadMessages}>
+        <Chip label={conversation.unreadMessages} color="primary" />
+      </Zoom>
     </Box>
   );
 };

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography, Chip, Zoom } from "@material-ui/core";
+import { Box, Typography, Badge, Zoom } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
@@ -13,12 +13,19 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: "bold",
     letterSpacing: -0.2,
   },
-  previewText: {
-    fontSize: 12,
-    fontWeight: ({ hasUnreadMessages }) => (hasUnreadMessages ? "600" : "400"),
-    color: ({ hasUnreadMessages }) =>
-      hasUnreadMessages ? "rgba(0, 0, 0, 0.87)" : "#9CADC8",
-    transition: 'all 0.4s ease',
+  newPreviewText: {
+    fontSize: theme.typography.fontSize,
+    fontWeight: "bold",
+    color: theme.palette.common.black,
+  },
+  seenPreviewText: {
+    fontSize: theme.typography.fontSize,
+    fontWeight: "normal",
+    color: theme.palette.common.faded,
+  },
+  unreadMessageBox: {
+    marginRight: theme.spacing(2),
+    marginTop: theme.spacing(),
   },
 }));
 
@@ -28,7 +35,7 @@ const ChatContent = (props) => {
 
   const hasUnreadMessages = conversation.unreadMessages > 0;
 
-  const classes = useStyles({ hasUnreadMessages });
+  const classes = useStyles();
 
   return (
     <Box className={classes.root}>
@@ -36,12 +43,17 @@ const ChatContent = (props) => {
         <Typography className={classes.username}>
           {otherUser.username}
         </Typography>
-        <Typography className={classes.previewText}>
+        <Typography className={hasUnreadMessages ? classes.newPreviewText : classes.seenPreviewText}>
           {latestMessageText}
         </Typography>
       </Box>
       <Zoom in={hasUnreadMessages}>
-        <Chip label={conversation.unreadMessages} color="primary" />
+        <Box className={classes.unreadMessageBox}>
+          <Badge
+            badgeContent={conversation.unreadMessages}
+            color="primary"
+          />
+        </Box>
       </Zoom>
     </Box>
   );

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -1,10 +1,11 @@
 import io from "socket.io-client";
 import store from "./store";
 import {
-  setNewMessage,
   removeOfflineUser,
   addOnlineUser,
+  moveLastReadIndex,
 } from "./store/conversations";
+import { receiveNewMessage } from "./store/utils/thunkCreators";
 
 const socket = io(window.location.origin);
 
@@ -19,8 +20,12 @@ socket.on("connect", () => {
     store.dispatch(removeOfflineUser(id));
   });
   socket.on("new-message", (data) => {
-    store.dispatch(setNewMessage(data.message, data.sender));
+    store.dispatch(receiveNewMessage(data.message, data.sender));
   });
+
+  socket.on("conversation-read", (conversationId) => {
+    store.dispatch(moveLastReadIndex(conversationId));
+  })
 });
 
 export default socket;

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -3,7 +3,7 @@ import store from "./store";
 import {
   removeOfflineUser,
   addOnlineUser,
-  moveLastReadIndex,
+  setConversationRead,
 } from "./store/conversations";
 import { receiveNewMessage } from "./store/utils/thunkCreators";
 
@@ -24,7 +24,7 @@ socket.on("connect", () => {
   });
 
   socket.on("conversation-read", (conversationId) => {
-    store.dispatch(moveLastReadIndex(conversationId));
+    store.dispatch(setConversationRead(conversationId));
   })
 });
 

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -5,7 +5,6 @@ import {
   removeOfflineUserFromStore,
   addMessageToStore,
   readAllMessagesFromConversation,
-  setReadToLatestMessage,
 } from "./utils/reducerFunctions";
 
 // ACTIONS
@@ -18,7 +17,6 @@ const SET_SEARCHED_USERS = "SET_SEARCHED_USERS";
 const CLEAR_SEARCHED_USERS = "CLEAR_SEARCHED_USERS";
 const ADD_CONVERSATION = "ADD_CONVERSATION";
 const SET_CONVERSATION_READ = "SET_CONVERSATION_READ";
-const MOVE_LAST_READ_INDEX = "MOVE_LAST_READ_INDEX";
 
 // ACTION CREATORS
 
@@ -29,13 +27,12 @@ export const gotConversations = (conversations) => {
   };
 };
 
-export const setNewMessage = (message, sender, activeConversation, userId) => {
+export const setNewMessage = (message, sender, userId) => {
   return {
     type: SET_MESSAGE,
     payload: {
       message,
       sender: sender || null,
-      activeConversation,
       userId
     },
   };
@@ -83,14 +80,6 @@ export const setConversationRead = (conversationId) => {
   };
 };
 
-export const moveLastReadIndex = (conversationId) => {
-  console.log(conversationId);
-  return {
-    type: MOVE_LAST_READ_INDEX,
-    payload: { conversationId }
-  }
-}
-
 // REDUCER
 
 const reducer = (state = [], action) => {
@@ -117,8 +106,6 @@ const reducer = (state = [], action) => {
       );
     case SET_CONVERSATION_READ:
       return readAllMessagesFromConversation(state, action.payload.conversationId);
-    case MOVE_LAST_READ_INDEX:
-      return setReadToLatestMessage(state, action.payload.conversationId);
     default:
       return state;
   }

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -4,6 +4,8 @@ import {
   addSearchedUsersToStore,
   removeOfflineUserFromStore,
   addMessageToStore,
+  readAllMessagesFromConversation,
+  setReadToLatestMessage,
 } from "./utils/reducerFunctions";
 
 // ACTIONS
@@ -15,6 +17,8 @@ const REMOVE_OFFLINE_USER = "REMOVE_OFFLINE_USER";
 const SET_SEARCHED_USERS = "SET_SEARCHED_USERS";
 const CLEAR_SEARCHED_USERS = "CLEAR_SEARCHED_USERS";
 const ADD_CONVERSATION = "ADD_CONVERSATION";
+const SET_CONVERSATION_READ = "SET_CONVERSATION_READ";
+const MOVE_LAST_READ_INDEX = "MOVE_LAST_READ_INDEX";
 
 // ACTION CREATORS
 
@@ -25,10 +29,15 @@ export const gotConversations = (conversations) => {
   };
 };
 
-export const setNewMessage = (message, sender) => {
+export const setNewMessage = (message, sender, activeConversation, userId) => {
   return {
     type: SET_MESSAGE,
-    payload: { message, sender: sender || null },
+    payload: {
+      message,
+      sender: sender || null,
+      activeConversation,
+      userId
+    },
   };
 };
 
@@ -67,6 +76,21 @@ export const addConversation = (recipientId, newMessage) => {
   };
 };
 
+export const setConversationRead = (conversationId) => {
+  return {
+    type: SET_CONVERSATION_READ,
+    payload: { conversationId }
+  };
+};
+
+export const moveLastReadIndex = (conversationId) => {
+  console.log(conversationId);
+  return {
+    type: MOVE_LAST_READ_INDEX,
+    payload: { conversationId }
+  }
+}
+
 // REDUCER
 
 const reducer = (state = [], action) => {
@@ -91,6 +115,10 @@ const reducer = (state = [], action) => {
         action.payload.recipientId,
         action.payload.newMessage
       );
+    case SET_CONVERSATION_READ:
+      return readAllMessagesFromConversation(state, action.payload.conversationId);
+    case MOVE_LAST_READ_INDEX:
+      return setReadToLatestMessage(state, action.payload.conversationId);
     default:
       return state;
   }

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -1,5 +1,5 @@
 export const addMessageToStore = (state, payload) => {
-  const { message, sender, activeConversation, userId } = payload;
+  const { message, sender, userId } = payload;
 
   const newMessageCount = userId !== message.senderId ? 1 : 0;
 
@@ -18,18 +18,14 @@ export const addMessageToStore = (state, payload) => {
   const convoToUpdate = state.find(convo => convo.id === message.conversationId);
   
   if (!convoToUpdate) {
-    // the find method can return undefined
-    // this check is to prevent the client from erroring out or becoming unresponsive
+    // this check is to prevent the client from erroring or becoming unresponsive
+    // if convoToUpdate is undefined
     return state;
   }
-
-  const updatedUnreadMessages = convoToUpdate.id === activeConversation
-    ? 0
-    : convoToUpdate.unreadMessages + newMessageCount;
   
   const updatedConvo = {
     ...convoToUpdate,
-    unreadMessages: updatedUnreadMessages,
+    unreadMessages: convoToUpdate.unreadMessages + newMessageCount,
     latestMessageText: message.text,
     messages: [
       ...convoToUpdate.messages,
@@ -108,28 +104,13 @@ export const addNewConvoToStore = (state, recipientId, message) => {
 
 export const readAllMessagesFromConversation = (state, conversationId) => {
   return state.map((convo) => {
-    if (
-      convo.id === conversationId
-      && convo.messages.length > 0
-      && convo.unreadMessages > 0
-    ) {
-      return {
-        ...convo,
-        unreadMessages: 0
-      }
-    }
-    return convo;
-  });
-}
-
-export const setReadToLatestMessage = (state, conversationId) => {
-  return state.map((convo) => {
     if (convo.id === conversationId) {
       return {
         ...convo,
+        unreadMessages: 0,
         lastReadMessageIndex: convo.messages.length - 1
       };
     }
     return convo;
-  })
-}
+  });
+};

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -101,7 +101,7 @@ const transmitConversationRead = (conversationId) => {
 export const receiveNewMessage = (message, sender) => (dispatch, getGlobalState) => {
   const { activeConversation, user, conversations } = getGlobalState();
   const activeConvo = conversations.find(convo => convo.otherUser.username === activeConversation);
-  const activeConvoId = activeConvo && activeConvo.id;
+  const activeConvoId = activeConvo?.id;
   dispatch(setNewMessage(message, sender, user ? user.id : null));
 
   if (activeConvoId === message.conversationId && user.id !== message.senderId) {

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -5,6 +5,7 @@ import {
   addConversation,
   setNewMessage,
   setSearchedUsers,
+  setConversationRead,
 } from "../conversations";
 import { gotUser, setFetchingStatus } from "../user";
 
@@ -91,6 +92,45 @@ const sendMessage = (data, body) => {
   });
 };
 
+const transmitConversationRead = (conversationId) => {
+  socket.emit("conversation-read", conversationId);
+};
+
+// attach the current active conversation and userId to the new message before it gets to the reducer util function
+export const receiveNewMessage = (message, sender) => (dispatch, getGlobalState) => {
+  const { activeConversation, user, conversations } = getGlobalState();
+  const activeConvo = conversations.find(convo => convo.otherUser.username === activeConversation);
+  const activeConvoId = activeConvo && activeConvo.id;
+  if (activeConvoId === message.conversationId && user.id !== message.senderId) {
+    dispatch(readMessage(message.id, message.conversationId));
+  }
+  dispatch(setNewMessage(message, sender, activeConvoId, user ? user.id : null));
+}
+
+export const readConversation = (conversationId) => async (dispatch) => {
+  try {
+    await axios.post("/api/conversations/read", {
+      conversationId
+    });
+    transmitConversationRead(conversationId);
+    dispatch(setConversationRead(conversationId));
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+export const readMessage = (messageId, conversationId) => async (dispatch) => {
+  try {
+    await axios.post("/api/messages/read", {
+      messageId,
+      conversationId
+    });
+    transmitConversationRead(conversationId);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 // message format to send: {recipientId, text, conversationId}
 // conversationId will be set to null if its a brand new conversation
 export const postMessage = (body) => async (dispatch) => {
@@ -100,7 +140,7 @@ export const postMessage = (body) => async (dispatch) => {
     if (!body.conversationId) {
       dispatch(addConversation(body.recipientId, data.message));
     } else {
-      dispatch(setNewMessage(data.message));
+      dispatch(receiveNewMessage(data.message));
     }
 
     sendMessage(data, body);

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -1,6 +1,6 @@
-import { createMuiTheme } from "@material-ui/core";
+import { createTheme } from "@material-ui/core";
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   typography: {
     fontFamily: "Open Sans, sans-serif",
     fontSize: 14,
@@ -8,7 +8,7 @@ export const theme = createMuiTheme({
       textTransform: "none",
       letterSpacing: 0,
       fontWeight: "bold"
-    }
+    },
   },
   overrides: {
     MuiInput: {
@@ -19,6 +19,7 @@ export const theme = createMuiTheme({
   },
   palette: {
     primary: { main: "#3A8DFF" },
-    secondary: { main: "#B0B0B0" }
+    secondary: { main: "#B0B0B0" },
+    common: { faded: "9CADC8" },
   }
 });

--- a/server/bin/www
+++ b/server/bin/www
@@ -54,6 +54,10 @@ io.on("connection", (socket) => {
       socket.broadcast.emit("remove-offline-user", id);
     }
   });
+
+  socket.on("conversation-read", (conversationId) => {
+    socket.broadcast.emit("conversation-read", conversationId);
+  });
 });
 
 sessionStore

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -10,6 +10,11 @@ const Message = db.define("message", {
     type: Sequelize.INTEGER,
     allowNull: false,
   },
+  read: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  },
 });
 
 module.exports = Message;

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -94,39 +94,4 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.post("/read", async (req, res, next) => {
-  try {
-    if (!req.user) {
-      return res.sendStatus(401);
-    }
-
-    const userId = req.user.id;
-    const { conversationId } = req.body;
-
-    const conversation = await Conversation.findOne({
-      where: {
-        id: conversationId,
-        [Op.or]: {
-          user1Id: userId,
-          user2Id: userId,
-        }
-      }
-    });
-
-    if (!conversation) {
-      res.sendStatus(401);
-    }
-
-    await Message.update({ read: true }, {
-      where: {
-        conversationId
-      }
-    });
-
-    res.sendStatus(201);
-  } catch (error) {
-    next(error);
-  }
-});
-
 module.exports = router;


### PR DESCRIPTION
Closes [#2](https://github.com/benyakirten/messenger-1384/issues/2 'Ticket #2')

The ticket adds a new feature to the website: unread messages. To accomplish this goal, there were two fundamental parts: creating a message read status and tracking it. I created my solution with the following assumptions:

1. A conversation can only happen between two people
2. The only way to interact with the backend is through the frontend, and to send a message through the frontend requires opening the chat to all previous messages.
3. Consequently, only one side of a conversation can have unread messages.

<img width="1218" alt="Screen Shot 2021-10-28 at 12 17 43 PM" src="https://user-images.githubusercontent.com/73619102/139312685-3853acc9-f5b1-43fc-a9ea-cb71efab940f.png">

To do this, I added the following features:

On the server:

1. Add a read field to the message field with a default value of false
2. Add the POST /read API route to conversationsto mark all messages in a conversation as read
2. Add a POST /read API route to messages to mark one message as read
4. Add two fields to the response object of any GET requests to /api/conversations: 1. the amount of unread messages by the other party and 2. the index of the last read message.
5. Broadcast to all other users the id of the conversation that has been read when a user transmits the 'conversation-read' event 

On the client:

1. Route new messages to the receiveNewMessage thunk which extracts information from the global state and passes it to the addMessageToStore reducer function. It extracts the ID of the active conversation (or false if there is no active conversation or if the conversation belongs to a different user) and the userId. If the active conversation ID is the same as the conversation the message belongs to AND the receiver is not the sender of a message, it forwards the messageId to the readMessage thunk before calling the addMessageToStore function.
2. Add the socket event 'conversation-read' so that the other user in the conversation can update their UI.
2. Add the readMessage thunk which sends a post request to /api/messages/read with the message ID so the backend marks the message as read. Then the socket emits the 'conversation-read' event  Finally, it calls the readAllMessagesInConversation reducer function with the conversation ID.
3. Add a readConversation thunk. It calls the /api/conversations/post method with the conversation ID so the backend marks all messages in a conversation as read. Then it calls the readAllMessagesInConversation if there are unread messages. Finally, it calls the socket to transmit the 'conversation-read' event with the conversation ID.
4. Add the readAllMessagesInConversation reducer function changes the amount of unread messages in a conversation to 0 and sets the latestReadMessageIndex to the latest message in a conversation. This event assumes that is only called when a conversation is opened or a new message is received (and not transmitted) and before the current user can transmit a message to the other party of a conversation.
5. Change the addMessageToStore reducer function so it keeps track of when the whether the unread message count should be incremented. There are two reasons why not: 1. the sender of the message is the user, 2. the receiver of the message has the conversation open as the activeChat (this check will only happen on the receiver's UI).
6. Add a chip to the sidebar's ChatContent component that displays the amount of unread messages in a conversation.
7. Dispatch the readConversation thunk with the conversation ID when user switches active conversation.
8. Add the LastReadAvatar component to mark the last message read by the other party of a conversation.
9. Add a LastReadAvatar to the ActiveChat/Messages component if the index of the last message is equal to the index of the message being rendered.

Other bug fix on the client side:

1. Because of the changes in the last merge, the addMessageToStore utility function now calls the Array.find method to find the latest conversation if the conversation isn't a new one and returns data based on that. The find function can sometimes return undefined in the case of a third client connecting. Now, if Array.find returns undefined, the state is returned unmodified.


Possible alternative approach is
1. The amount of unread messages and latest message could be calculated and tracked on the frontend only. It would potentially remove the need to access the globalState from a thunk. I did not take this approach for the following reasons:
> 1. Knowing the amount of unread messages is useful in multiple places (in the sidebar's Chat Content component, whether to dispatch  readAllMessagesInConversation when the activeChat changes).
> 2. The solve this problem there are two approaches. Either a thunk can be used like the current solution, or the amount of unread messages would be calculated in the Chat or ChatContent component then dispatched to the store. Likewise, the last read message would have to be calculated in the ActiveChat component.
> 3. Though everything would work correctly, it feels wrong to me and a strange approach to React's unidirectional data flow. I think thsi for two reasons: 1. because the initial data is calculated and components that then feed into the data and 2. the database doesn't keep track of this information even though it already keeps track of which messages have been read.

2. The backend could track the last two messages read for each client in each conversation. I did implement this approach because it seems completely counterintuitive to me and would make the codebase more difficult to understand, even more so than my solution.