### PR TITLE
draft - database redesign for 3+ users in a conversation

### DIFF
--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -1,25 +1,121 @@
 const { Op } = require("sequelize");
 const db = require("../db");
+const UserConversation = require("./userConversation");
 const Message = require("./message");
+const User = require("./user");
+
+// Helper function to reduce repeated logic
+async function tryOrReturnNull(fn, thisArg = null, ...args) {
+  try {
+    const res = await fn.apply(thisArg, args);
+    return res;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
 
 const Conversation = db.define("conversation", {});
 
-// find conversation given two user Ids
-
-Conversation.findConversation = async function (user1Id, user2Id) {
-  const conversation = await Conversation.findOne({
-    where: {
-      user1Id: {
-        [Op.or]: [user1Id, user2Id]
-      },
-      user2Id: {
-        [Op.or]: [user1Id, user2Id]
-      }
+// Add all users in an array to a conversation, users should be an array (or iterable) and firstMessage a Message type without a conversationId
+// This method will be called in one of two situations:
+// 1. when a user sends a message in a conversation for the first time
+// 2. when someone invites a third person to a conversation before a message has been sent
+Conversation.startConversation = function (users, firstMessage) {
+  return tryOrReturnNull(async () => {
+    const conversation = await Conversation.create();
+    await conversation.addUser(users, { through: { lastReadMessage: -1 } });
+    if (firstMessage) {
+      await Message.create({
+        ...firstMessage,
+        conversationId: conversation.id,
+      });
     }
+    return conversation;
   });
+};
 
-  // return conversation or null if it doesn't exist
-  return conversation;
+Conversation.joinConversation = function (conversationId, userId) {
+  return tryOrReturnNull(async () => {
+    const conversation = await Conversation.findOne({
+      where: {
+        id: conversationId,
+      },
+      include: [
+        {
+          model: User,
+          attributes: ["id"],
+        },
+        { model: Message },
+      ],
+    });
+
+    // it is easy to test if a conversation has a user in the query, but it is harder to test that a conversation doesn't have a user
+    const allUsers = conversation.toJSON().users
+    if (allUsers.find(user => user.id === userId)) {
+      throw new Error(`User with ID ${userId} already part of conversation with ID ${conversationId}`);
+    }
+
+     // Either the new user's position can default to -1 or the current message count - 1
+    await conversation.addUser(userId, {
+      through: { lastReadMessage: conversation.messages.length - 1 },
+    });
+    return conversation;
+  });
+};
+
+Conversation.leaveConversation = function (conversationId, userId) {
+  return tryOrReturnNull(async () => {
+    const conversation = await Conversation.findOne({
+      where: {
+        id: conversationId,
+      },
+      include: [
+        {
+          model: User,
+          where: {
+            id: userId,
+          },
+          attributes: ["id"],
+        },
+      ],
+    });
+
+    await conversation.removeUser(userId);
+    return conversation;
+  });
+};
+
+Conversation.readConversation = function (conversationId, userId) {
+  return tryOrReturnNull(async () => {
+    const conversation = await Conversation.findOne({
+      where: {
+        id: conversationId,
+      },
+      include: [
+        { model: Message },
+        {
+          model: User,
+          where: {
+            id: userId,
+          },
+          attributes: ["id"],
+        },
+      ],
+    });
+
+    const updatedLastReadMessageIndex = conversation.messages.length - 1;
+
+    const userConversation = await UserConversation.findOne({
+      where: { conversationId, userId },
+    });
+
+    await userConversation.update({
+      lastReadMessage: updatedLastReadMessageIndex,
+    });
+
+    return updatedLastReadMessageIndex;
+  });
 };
 
 module.exports = Conversation;

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,17 +1,18 @@
 const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
+const UserConversation = require("./userConversation");
 
 // associations
 
-User.hasMany(Conversation);
-Conversation.belongsTo(User, { as: "user1" });
-Conversation.belongsTo(User, { as: "user2" });
+User.belongsToMany(Conversation, { through: UserConversation });
+Conversation.belongsToMany(User, { through: UserConversation });
 Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
 
 module.exports = {
   User,
   Conversation,
-  Message
+  Message,
+  UserConversation
 };

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -10,11 +10,6 @@ const Message = db.define("message", {
     type: Sequelize.INTEGER,
     allowNull: false,
   },
-  read: {
-    type: Sequelize.BOOLEAN,
-    allowNull: false,
-    defaultValue: false
-  },
 });
 
 module.exports = Message;

--- a/server/db/models/userConversation.js
+++ b/server/db/models/userConversation.js
@@ -1,0 +1,12 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+const userConversation = db.define("user_conversation", {
+  lastReadMessage: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: -1,
+  },
+});
+
+module.exports = userConversation;


### PR DESCRIPTION
Closes [#3](https://github.com/benyakirten/messenger-1384/issues/3 'Ticket #3')

# Draft plan for implementation of group chats

## Addressing concern 1

### On the backend
1. API routes need to be corrected to fit the new architecture. Besides updating the syntax, there are need for the following chage:
> 1. Update GET route for /api/conversations - last read message index is now stored in the UserConversation join table and no longer needs to be tabulated. Conversely, the amount of unread messages needs to be calculated by subtracting the total amount of messages by this index + 1.
> 2. Update POST route for /api/messages - it needs to have an explicit conversationId. Conversations are no longer unique to a pair of users and so they cannot be looked up according to a pair of users.
> 3. Update PATCH route for /api/messages/read - it needs to call the new readConversation method and use the return value.
> 4. Create POST route for /api/conversations - Conversations must now be created explicitly with an optional first message before messages can be exchanged normally.
> 5. Create PATCH routes for /api/conversations/join and /api/conversaions/leave - Routes need to be added for a single user to join and leave a conversation.
2. How WebSockets relay data is a problem if 3+ users connect to the service. Right now, sockets broadcasts every event to every user. For the add-online-user and remove-offline-user features this is fine. However, for both the new-message and the conversation-read events as well as the those proposed in this draft, it presents a problem. The frontend could filter for the relevant events, but, for security reasons and to reduce traffic, a check on the backend before the information is relayed functions much better. The backend could store and organize the relevant information through redis or something similar.

### On the frontend
1. The Sidebar will need to be some sort of modification to identify how many and who is in a conversation. Possibly, the current badge avatar could become a Material UI AvatarGroup if it's a group conversation.
2. The frontend needs to separate conversations into two groups: ones that have IDs and ones that don't. This allows a user can begin a new chat with someone with whom they already have a conversation in case they want to start another chat with the other user. Possibly, new chats could also be initiated through a button on the sidebar near the search box.
3. If a conversation has more than 2 participants, there needs to be a second, more explicit component to see the all the users inside the ActiveChat,.
4. There needs to be an interface to add someone to a group or for a user to leave it, possibly through a dropdown menu on the Header component of the ActiveChat.
5. The Messages component needs to render an Avatar for every user that has their last read message that index. Similar to the sidebar, an AvatarGroup component can be used if multiple readers have reached the same index.
6. Regarding store functionality:
> 1. Thunk creators will need to be created for joining/leaving a conversation. They will need to call the api routes with the appropriate actions (API calls), emit an event on the socket then call reducer functions.
> 2. Right now, the only way to create a conversation is via the postMessage thunk. There needs to be two thunks, one to send a message and the other for creating a new conversation. If the message is in a preexisting conversation, it goes to the first thunk. If a third person joins a conversation that hasn't yet been initialized, it goes to the second thunk. If a new conversation starts between two users, it can go to either thunk. However, due to my proposed draft, it would call the POST /api/conversations route, which the second thunk will already need to call.
> 3. Conversations will no longer have otherUser as part of them but instead an array of usernames (perhaps sorted).
> 4. Reducer utility functions will be needed to add a user to/remove a user from a conversation.
> 5. Conversations now need additional actions/action creators/reducer cases for these events.

### On both ends
1. WebSockets will need to transmit when someone joins a chat and when someone leaves a chat.
2. The conversation-read event will need to also include the emitting userId besides the conversationId.

## Addressing concern 2

1. Model migrations need to occur. In this case, it can be done through sequelize-cli.
2. The migrations should be the following:
> 1. Many to Many relationship set between User and Conversation instead of two aliased One To Many relationships.
> 2. UserConversation: a new join table between User and Conversation with the lastReadMessage field that's non-nullable and has a default of -1. Its value needs to be calculated on a per-user basis.
> 3. Conversation: user1Id and user2Id need to removed as fields on a conversation and the data from those fields needs to be added to the UserConversation join table.
> 4. Messages: remove the read field from the table.
3. seed.js and tests need to be updated.

## Alternative approaches

1. As long as a PostgreSQL database is used, the participants in a conversation and their last read messages could be stored as two fields using arrays in the conversation table without using a join table. However, the data would not be relational, defeating the point of using a SQL database.
2. What messages have been read could be tracked by the message in the conversation by having a One to Many relationship with Users. A few other chat applications seem to track only the latest message and if it has been read.

## Additional suggestions:

1. All IDs/Primary keys should use UUIDs instead of sequential integers.
2. There should be a limit to how many messages are loaded into a conversation by default, either by quantity or date. Messages under the limit should be cached in something like redis and only messages over the limit should be retrieved from the database.
3. Conversations could have a public or private property as well as a title. One solution might be to give each conversation a title that only becomes visible if the number of users in a group when it becomes a group conversation (3+ users). Another solution might be to make two models: private conversations (between two people) and group conversations (all others) that have a title and privacy setting as fields and/or roles in the join table.